### PR TITLE
[WIP] Manager: add the ability to search notes and focus them by double-click.

### DIFF
--- a/usr/lib/sticky/manager.py
+++ b/usr/lib/sticky/manager.py
@@ -3,6 +3,7 @@
 from gi.repository import Gdk, Gio, GLib, GObject, Gtk, Pango
 from note_buffer import NoteBuffer
 from common import HoverBox
+from util import clean_text
 
 NOTE_TARGETS = [Gtk.TargetEntry.new('note-entry', Gtk.TargetFlags.SAME_APP, 1)]
 
@@ -341,8 +342,8 @@ class NotesManager(object):
             self.generate_previews()
 
     def on_search_changed(self, *args):
-        search_text = self.search_box.get_text()
-        if search_text.strip() == '':
+        search_text = self.search_box.get_text().lower().strip()
+        if search_text == '':
             self.generate_previews()
 
         else:
@@ -350,7 +351,7 @@ class NotesManager(object):
 
             for group_name in self.file_handler.get_note_group_names():
                 for note_info in self.file_handler.get_note_list(group_name):
-                    if note_info['title'].find(search_text) != -1 or note_info['text'].find(search_text) != -1:
+                    if note_info['title'].lower().find(search_text) != -1 or clean_text(note_info['text']).find(search_text) != -1:
                         self.search_model.append(Note(note_info, group_name))
 
             self.note_view.bind_model(self.search_model, self.create_note_entry)

--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -818,6 +818,11 @@ class Application(Gtk.Application):
         for note_info in self.file_handler.get_note_list(self.note_group):
             self.generate_note(note_info)
 
+    def focus_note(self, note_info):
+        for note in self.notes:
+            if note.get_info() == note_info:
+                note.present_with_time(0)
+
     def on_lists_changed(self, *args):
         if not self.note_group in self.file_handler.get_note_group_names():
             self.change_visible_note_group()

--- a/usr/lib/sticky/util.py
+++ b/usr/lib/sticky/util.py
@@ -76,3 +76,25 @@ def gnote_to_internal_format(file_path):
         category = _("Unfiled")
 
     return (category, info, is_template)
+
+def clean_text(text):
+    current_index = 0
+    new_text = ''
+    while True:
+        next_index = text.find('#', current_index)
+        new_text += text[current_index:next_index]
+
+        if next_index == -1:
+            return new_text.lower()
+
+        if text[next_index:next_index+2] == '##':
+            new_text += '#'
+            current_index = next_index + 2
+        elif text[next_index:next_index+6] == '#check':
+            current_index = next_index + 8
+        elif text[next_index:next_index+7] == '#bullet':
+            current_index = next_index + 8
+        elif text[next_index:next_index+4] == '#tag':
+            current_index = text.find(':', next_index+6) + 1
+        else:
+            current_index += 1

--- a/usr/share/sticky/manager.ui
+++ b/usr/share/sticky/manager.ui
@@ -93,32 +93,6 @@
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">never</property>
-                <property name="shadow_type">in</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkFlowBox" id="note_view">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="valign">start</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkToolbar">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -177,6 +151,26 @@
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToolItem">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <child>
+                      <object class="GtkSearchEntry" id="search_box">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="primary_icon_name">edit-find-symbolic</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <property name="primary_icon_sensitive">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
                     <property name="expand">True</property>
                     <property name="homogeneous">True</property>
                   </packing>
@@ -187,6 +181,33 @@
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">never</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkViewport">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkFlowBox" id="note_view">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">start</property>
+                        <property name="activate_on_single_click">False</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>


### PR DESCRIPTION
* A search box was added to the manager
* the toolbar for notes (which now contains the search box) was moved to the top
* searching in the search box replaces the visible notes view with all notes that match the search string
* activating (by double clicking or pressing enter) a note in the note view now causes that note to be raised to the top and given keyboard focus. If the group the note belongs to is not the currently selected group (ie. during a search) that group will also be selected.