### PR TITLE
Overwrite consent

### DIFF
--- a/usr/lib/sticky/common.py
+++ b/usr/lib/sticky/common.py
@@ -258,6 +258,10 @@ class FileHandler(GObject.Object):
         self.save_note_list()
 
     def new_group(self, group_name):
+        if group_name in self.notes_lists:
+            if not confirm(_("Overwrite to Existing Group"), _("Are you sure you want to overwrite the group %s?") % group_name, self.window):
+                return
+
         self.notes_lists[group_name] = []
 
         self.save_note_list()

--- a/usr/lib/sticky/manager.py
+++ b/usr/lib/sticky/manager.py
@@ -200,6 +200,7 @@ class NotesManager(object):
     def __init__(self, app, file_handler):
         self.app = app
         self.dragged_note = None
+        self.on_activate = False
 
         self.file_handler = file_handler
         self.file_handler.connect('group-changed', self.on_list_changed)
@@ -405,12 +406,17 @@ class NotesManager(object):
             self.generate_group_list()
 
         def maybe_done(entry, *args):
+            if self.on_activate:
+                return
+            self.on_activate = True
+            
             group_name = entry.get_text()
             if group_name == '':
                 group_name = None
             else:
                 self.file_handler.new_group(group_name)
 
+            self.on_activate = False
             clean_up(entry)
             callback(group_name)
 


### PR DESCRIPTION
Hi,
Currently, if we create an group with name which has already defined will overwrite to other group. It will be nice to have a consent dialog for that.
