### PR TITLE
manager: Clean up some styling in the sidebar

### DIFF
--- a/usr/lib/sticky/manager.py
+++ b/usr/lib/sticky/manager.py
@@ -75,6 +75,8 @@ class GroupEntry(Gtk.ListBoxRow):
         self.item = item
         self.file_handler = self.item.file_handler
 
+        self.props.height_request = 35
+
         self.hoverbox = HoverBox()
         self.add(self.hoverbox)
 
@@ -115,15 +117,13 @@ class GroupEntry(Gtk.ListBoxRow):
         return Gdk.EVENT_PROPAGATE
 
     def generate_content(self):
-        self.box = Gtk.Box(height_request=34)
+        self.box = Gtk.Box()
         self.hoverbox.add(self.box)
 
-        self.box.pack_start(Gtk.Box(height_request=16, width_request=16), False, False, 2)
-
-        label = Gtk.Label(label=self.item.name, halign=Gtk.Align.START, margin=5)
+        label = Gtk.Label(label=self.item.name, halign=Gtk.Align.START, margin_start=5)
         self.box.pack_start(label, True, True, 5)
 
-        image = Gtk.Image.new_from_icon_name('edit', Gtk.IconSize.BUTTON)
+        image = Gtk.Image.new_from_icon_name('document-edit-symbolic', Gtk.IconSize.BUTTON)
         button = Gtk.Button(image=image, relief=Gtk.ReliefStyle.NONE, name='manager-group-edit-button')
         self.box.pack_end(button, False, False, 2)
         button.connect('clicked', self.edit_group_name)

--- a/usr/share/sticky/sticky.css
+++ b/usr/share/sticky/sticky.css
@@ -55,8 +55,14 @@
 @define-color magenta5 #9d1094; /* selection */
 
 /* manager */
-#manager-group-edit-button {
+#manager-group-edit-button,
+#manager-group-edit-button:hover,
+#manager-group-edit-button:checked,
+#manager-group-edit-button:backdrop {
     border: none;
+    background: none;
+    color: inherit;
+    padding: 0 5px;
 }
 
 /* common */


### PR DESCRIPTION
Use a symbolic icon for the edit button and remove most of the button
styling. We don't need it and it doesn't look very good. Also tweak things
a bit so the rows don't change size when going from normal to edit mode.