### PR TITLE
New Features: Cycle Colors, Start Position and some other tweaks.

### DIFF
--- a/usr/lib/sticky/common.py
+++ b/usr/lib/sticky/common.py
@@ -343,7 +343,8 @@ def prompt(title, message, window):
     return (response == Gtk.ResponseType.OK, value)
 
 def confirm(title, message, window=None, settings=None, disable_key=None, disable_inverted=False):
-    dialog = Gtk.Dialog(title=title, transient_for=window, window_position=Gtk.WindowPosition.CENTER)
+    dialog = Gtk.Dialog(title=title, transient_for=window,
+        window_position=(Gtk.WindowPosition.CENTER if window is None else Gtk.WindowPosition.CENTER_ON_PARENT))
     dialog.add_button(_("No"), Gtk.ResponseType.NO)
     dialog.add_button(_("Yes"), Gtk.ResponseType.YES)
     dialog.set_default_response(Gtk.ResponseType.YES)

--- a/usr/lib/sticky/manager.py
+++ b/usr/lib/sticky/manager.py
@@ -258,7 +258,7 @@ class NotesManager(object):
         self.search_bar = self.builder.get_object('search_bar')
         GObject.Object.bind_property(search_toggle, 'active', self.search_bar, 'search_mode_enabled', GObject.BindingFlags.BIDIRECTIONAL)
 
-        self.builder.get_object('new_note').connect('clicked', self.new_note)
+        self.builder.get_object('new_note').connect('clicked', self.app.new_note)
         self.remove_note_button = self.builder.get_object('remove_note')
         self.remove_note_button.connect('clicked', self.remove_note)
 
@@ -457,9 +457,6 @@ class NotesManager(object):
 
     def get_selected_note(self):
         return self.note_view.get_selected_children()[0].item.info
-
-    def new_note(self, *args):
-        self.app.new_note()
 
     def create_new_group(self, callback):
         entry = Gtk.Entry(visible=True)

--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -482,7 +482,8 @@ class Note(Gtk.Window):
 
     def remove(self, *args):
         # this is ugly but I'm not sure how to make it look better :)
-        if (self.app.settings.get_boolean('disable-delete-confirm') or
+        if ((not self.title.get_text() and not self.buffer.get_internal_markup()) or
+            self.app.settings.get_boolean('disable-delete-confirm') or
             confirm(_("Delete Note"), _("Are you sure you want to remove this note?"),
                     self, self.app.settings, 'disable-delete-confirm')):
             self.emit('removed')

--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -562,6 +562,7 @@ class SettingsWindow(XApp.PreferencesWindow):
             colors.append(('random', _('Random')))
 
             page.pack_start(GSettingsComboBox(_("Default color"), SCHEMA, 'default-color', options=colors, valtype=str), False, False, 0)
+        page.pack_start(GSettingsSwitch(_("Cycle colors"), SCHEMA, 'cycle-colors'), False, False, 0)
 
         page.pack_start(GSettingsFontButton(_("Font"), SCHEMA, 'font', level=Gtk.FontChooserLevel.SIZE), False, False, 0)
         page.pack_start(GSettingsSwitch(_("Show spelling mistakes"), SCHEMA, 'inline-spell-check'), False, False, 0)
@@ -828,17 +829,26 @@ class Application(Gtk.Application):
     def new_note(self, *args):
         x = 40
         y = 40
-        while(True):
-            found = False
-            for note_info in self.file_handler.get_note_list(self.note_group):
-                if note_info['x'] == x and note_info['y'] == y:
-                    found = True
+        color = self.settings.get_string('default-color')
+        note_list = self.file_handler.get_note_list(self.note_group)
+        if note_list:
+            while(True):
+                found = False
+                for note_info in note_list:
+                    if note_info['x'] == x and note_info['y'] == y:
+                        found = True
+                        break
+                if not found:
                     break
-            if not found:
-                break
-            x += 20
-            y += 20
-        info = {'x': x, 'y': y}
+                x += 20
+                y += 20
+            if self.settings.get_boolean('cycle-colors'):
+                color_keys = list(COLORS)
+                try:
+                    color = color_keys[color_keys.index(note_list[-1]['color']) + 1]
+                except (ValueError, IndexError):
+                    color = color_keys[0]
+        info = {'x': x, 'y': y, 'color': color}
         note = self.generate_note(info)
         note.present_with_time(Gtk.get_current_event_time())
 

--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -75,6 +75,14 @@ SHORTCUTS = {
     ]
 }
 
+
+START_POSITIONS = {
+    'top-left': _("Top Left"),
+    'top-right': _("Top Right"),
+    'bottom-left': _("Bottom Left"),
+    'bottom-right': _("Bottom Right")
+}
+
 class Note(Gtk.Window):
     @GObject.Signal(flags=GObject.SignalFlags.RUN_LAST, return_type=bool,
                     accumulator=GObject.signal_accumulator_true_handled)
@@ -551,6 +559,8 @@ class SettingsWindow(XApp.PreferencesWindow):
         page = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         page.pack_start(GSettingsSpinButton(_("Default height"), SCHEMA, 'default-height', mini=50, maxi=2000, step=10), False, False, 0)
         page.pack_start(GSettingsSpinButton(_("Default width"), SCHEMA, 'default-width', mini=50, maxi=2000, step=10), False, False, 0)
+        start_posititions = [(x, y) for x, y in START_POSITIONS.items()]
+        page.pack_start(GSettingsComboBox(_("Default start position"), SCHEMA, 'default-start-position', options=start_posititions, valtype=str), False, False, 0)
         try:
             colors = [(x, y) for x, y in COLORS.items()]
             colors.append(('sep', ''))
@@ -827,12 +837,33 @@ class Application(Gtk.Application):
         self.update_dummy_window()
 
     def new_note(self, button, parent=None):
+        workarea_rect = Gdk.Monitor.get_workarea(
+            Gdk.Display.get_primary_monitor(Gdk.Display.get_default())
+            )
+        direction = [1, 1]
         if parent:
-            x = parent.x + 20
-            y = parent.y + 60
+            if parent.x > (workarea_rect.width / 2):
+                x = parent.x - 20
+                direction[0] = -1
+            else:
+                x = parent.x + 20
+            if parent.y > (workarea_rect.height / 2):
+                y = parent.y - 60
+                direction[1] = -1
+            else:
+                y = parent.y + 60
         else:
-            x = 40
-            y = 40
+            start_pos = self.settings.get_string('default-start-position').split('-')
+            if start_pos[1] == 'right':
+                x = workarea_rect.width - self.settings.get_uint('default-width') - 20
+                direction[0] = -1
+            else:
+                x = 20
+            if start_pos[0] == 'bottom':
+                y = workarea_rect.height - self.settings.get_uint('default-height') - 60
+                direction[1] = -1
+            else:
+                y = 20
         color = self.settings.get_string('default-color')
         note_list = self.file_handler.get_note_list(self.note_group)
         if note_list:
@@ -844,8 +875,8 @@ class Application(Gtk.Application):
                         break
                 if not found:
                     break
-                x += 20
-                y += 60
+                x += 20 * direction[0]
+                y += 60 * direction[1]
             if self.settings.get_boolean('cycle-colors'):
                 color_keys = list(COLORS)
                 try:

--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -157,7 +157,7 @@ class Note(Gtk.Window):
 
         add_icon = Gtk.Image.new_from_icon_name('sticky-add', Gtk.IconSize.BUTTON)
         add_button = Gtk.Button(image=add_icon, relief=Gtk.ReliefStyle.NONE, name='window-button', valign=Gtk.Align.CENTER)
-        add_button.connect('clicked', self.app.new_note)
+        add_button.connect('clicked', self.app.new_note, self)
         add_button.connect('button-press-event', self.on_title_click)
         add_button.set_tooltip_text(_("New Note"))
         self.title_bar.pack_end(add_button, False, False, 0)
@@ -826,9 +826,13 @@ class Application(Gtk.Application):
         self.notes_hidden = True
         self.update_dummy_window()
 
-    def new_note(self, *args):
-        x = 40
-        y = 40
+    def new_note(self, button, parent=None):
+        if parent:
+            x = parent.x + 20
+            y = parent.y + 60
+        else:
+            x = 40
+            y = 40
         color = self.settings.get_string('default-color')
         note_list = self.file_handler.get_note_list(self.note_group)
         if note_list:
@@ -841,7 +845,7 @@ class Application(Gtk.Application):
                 if not found:
                     break
                 x += 20
-                y += 20
+                y += 60
             if self.settings.get_boolean('cycle-colors'):
                 color_keys = list(COLORS)
                 try:

--- a/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
@@ -20,6 +20,26 @@
       </description>
     </key>
 
+    <key name='default-start-position' type='s'>
+      <default>"top-left"</default>
+      <summary>Default Start Position</summary>
+      <choices>
+        <choice value='top-left'/>
+        <choice value='top-right'/>
+        <choice value='bottom-left'/>
+        <choice value='bottom-right'/>
+      </choices>
+      <aliases>
+        <alias value='Top Left' target='top-left'/>
+        <alias value='Top Right' target='top-right'/>
+        <alias value='Bottom Left' target='bottom-left'/>
+        <alias value='Bottom Right' target='bottom-right'/>
+      </aliases>
+      <description>
+        The position that new notes will start at on the screen.
+      </description>
+    </key>
+
     <key name='default-color' type='s'>
       <default>"yellow"</default>
       <summary>Default Color</summary>

--- a/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
@@ -49,6 +49,14 @@
       </description>
     </key>
 
+    <key name='cycle-colors' type='b'>
+      <default>false</default>
+      <summary>Cycle colors</summary>
+      <description>
+        If true, each new not will be a differnt color from the last.
+      </description>
+    </key>
+
     <key name='font' type='s'>
       <default>"Arial 14"</default>
       <summary>The note text font</summary>


### PR DESCRIPTION
### Cycle Colors
#### Problem
I like to have my notes different colors so I can quickly go to the specific one I need with just a quick glance.
Using Random as the default color didn't quite cut it for me as I would quite often end up with 2 or 3 notes in a row with the same color (which were annoying to close as discussed below), and it would take a while to remember what color of note contained what information.
#### Solution
Adding the option (Preferences > Notes > Cycle colors) to have the notes cycle through the possible colors (starting with the specified default color) not only ensures new notes are a different color, but once you get used to the color sequence it is amazingly easy to just know what information you have put where at a glance.

### Start Position
I much prefer having my notes in the top right of my screen, so have added an option to allow you to choose which corner of the screen new notes are created. This also detects which direction to create new notes, so if you move a note to another corner, new notes will always be created towards the center of the screen.

### Additional Tweaks
#### Center Close Dialog on Note
I like having the confirm dialog when closing notes to prevent mistakes, however having it open in the center of the screen is especially annoying when trying to quickly close a few notes that are at the side of the screen. Having the dialog center on the note just makes much more sense to me.
#### Skip Close Dialog on Empty Note
The one time I don't like having the confirm dialog is when a note is empty, so I've added a check to skip the dialog is there is no title or text.
#### Position New Notes Relative To Parent
Preferring to keep my notes to the right of my screen in some cases makes creating new notes (which appear on the left) annoying. Changing this so if a note is created using the "+" button on another note, the new one is positioned relative to it's "parent" note. Also the positioning has been adjusted to make grabbing the header on a below note easier.