### PR TITLE
Confirm Close Dialog Tweaks

### DIFF
--- a/usr/lib/sticky/common.py
+++ b/usr/lib/sticky/common.py
@@ -343,7 +343,8 @@ def prompt(title, message, window):
     return (response == Gtk.ResponseType.OK, value)
 
 def confirm(title, message, window=None, settings=None, disable_key=None, disable_inverted=False):
-    dialog = Gtk.Dialog(title=title, transient_for=window, window_position=Gtk.WindowPosition.CENTER)
+    dialog = Gtk.Dialog(title=title, transient_for=window,
+        window_position=(Gtk.WindowPosition.CENTER if window is None else Gtk.WindowPosition.CENTER_ON_PARENT))
     dialog.add_button(_("No"), Gtk.ResponseType.NO)
     dialog.add_button(_("Yes"), Gtk.ResponseType.YES)
     dialog.set_default_response(Gtk.ResponseType.YES)

--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -482,8 +482,8 @@ class Note(Gtk.Window):
 
     def remove(self, *args):
         # this is ugly but I'm not sure how to make it look better :)
-        if ((not self.title.get_text() and not self.buffer.get_internal_markup()) or
-            self.app.settings.get_boolean('disable-delete-confirm') or
+        if (self.app.settings.get_boolean('disable-delete-confirm') or
+            (not self.title.get_text() and not self.buffer.get_internal_markup()) or
             confirm(_("Delete Note"), _("Are you sure you want to remove this note?"),
                     self, self.app.settings, 'disable-delete-confirm')):
             self.emit('removed')

--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -482,7 +482,8 @@ class Note(Gtk.Window):
 
     def remove(self, *args):
         # this is ugly but I'm not sure how to make it look better :)
-        if (self.app.settings.get_boolean('disable-delete-confirm') or
+        if ((not self.title.get_text() and not self.buffer.get_internal_markup()) or
+            self.app.settings.get_boolean('disable-delete-confirm') or
             confirm(_("Delete Note"), _("Are you sure you want to remove this note?"),
                     self, self.app.settings, 'disable-delete-confirm')):
             self.emit('removed')


### PR DESCRIPTION
### Center Close Dialog on Note
I like having the confirm dialog when closing notes to prevent mistakes, however having it open in the center of the screen is especially annoying when trying to quickly close a few notes that are at the side of the screen. Having the dialog center on the note just makes much more sense to me.
### Skip Close Dialog on Empty Note
The one time I don't like having the confirm dialog is when a note is empty, so I've added a check to skip the dialog is there is no title or text.