### PR TITLE
Cycle Colors Feature

### DIFF
--- a/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
@@ -53,7 +53,7 @@
       <default>false</default>
       <summary>Cycle colors</summary>
       <description>
-        If true, each new not will be a differnt color from the last.
+        If true, each new not will be a different color from the last.
       </description>
     </key>
 

--- a/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
@@ -49,6 +49,14 @@
       </description>
     </key>
 
+    <key name='cycle-colors' type='b'>
+      <default>false</default>
+      <summary>Cycle colors</summary>
+      <description>
+        If true, each new not will be a differnt color from the last.
+      </description>
+    </key>
+
     <key name='font' type='s'>
       <default>"Arial 14"</default>
       <summary>The note text font</summary>


### PR DESCRIPTION
### Cycle Colors
#### My Problem
I like to have my notes different colors so I can quickly go to the specific one I need with just a quick glance.
Using Random as the default color didn't quite cut it for me as I would quite often end up with 2 or 3 notes in a row with the same color (which were annoying to close as discussed below), and it would take a while to remember what color of note contained what information.
#### My Solution
Adding the option (Preferences > Notes > Cycle colors) to have the notes cycle through the possible colors (starting with the specified default color) not only ensures new notes are a different color, but once you get used to the color sequence it is amazingly easy to just know what information you have put where at a glance.