### PR TITLE
Start Position Feature

### DIFF
--- a/usr/lib/sticky/manager.py
+++ b/usr/lib/sticky/manager.py
@@ -258,7 +258,7 @@ class NotesManager(object):
         self.search_bar = self.builder.get_object('search_bar')
         GObject.Object.bind_property(search_toggle, 'active', self.search_bar, 'search_mode_enabled', GObject.BindingFlags.BIDIRECTIONAL)
 
-        self.builder.get_object('new_note').connect('clicked', self.new_note)
+        self.builder.get_object('new_note').connect('clicked', self.app.new_note)
         self.remove_note_button = self.builder.get_object('remove_note')
         self.remove_note_button.connect('clicked', self.remove_note)
 
@@ -457,9 +457,6 @@ class NotesManager(object):
 
     def get_selected_note(self):
         return self.note_view.get_selected_children()[0].item.info
-
-    def new_note(self, *args):
-        self.app.new_note()
 
     def create_new_group(self, callback):
         entry = Gtk.Entry(visible=True)

--- a/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
@@ -20,6 +20,26 @@
       </description>
     </key>
 
+    <key name='default-start-position' type='s'>
+      <default>"top-left"</default>
+      <summary>Default Start Position</summary>
+      <choices>
+        <choice value='top-left'/>
+        <choice value='top-right'/>
+        <choice value='bottom-left'/>
+        <choice value='bottom-right'/>
+      </choices>
+      <aliases>
+        <alias value='Top Left' target='top-left'/>
+        <alias value='Top Right' target='top-right'/>
+        <alias value='Bottom Left' target='bottom-left'/>
+        <alias value='Bottom Right' target='bottom-right'/>
+      </aliases>
+      <description>
+        The position that new notes will start at on the screen.
+      </description>
+    </key>
+
     <key name='default-color' type='s'>
       <default>"yellow"</default>
       <summary>Default Color</summary>


### PR DESCRIPTION
### Start Position
I much prefer having my notes in the top right of my screen, so have added an option to allow you to choose which corner of the screen new notes are created. This also detects which direction to create new notes, so if you move a note to another corner, new notes will always be created towards the centre of the screen.
### Position New Notes Relative To Parent
If a note is created using the "+" button on another note, the new one is positioned relative to it's "parent" note. Also the positioning has been adjusted to make grabbing the header on a behind note easier.