### PR TITLE
Replace Random Color Option With Cycle Colors

### DIFF
--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import random
 import sys
 
 import gi
@@ -111,8 +110,19 @@ class Note(Gtk.Window):
             name='sticky-note'
         )
 
-        if self.color == 'random':
-            self.color = random.choice(list(COLORS.keys()))
+        if self.color == 'cycle':
+            if self.app.settings.get_string('last-color') == '':
+                last_color = self.color
+            else:
+                last_color = self.app.settings.get_string('last-color')
+
+            color_keys = list(COLORS)
+            try:
+                self.color = color_keys[color_keys.index(last_color) + 1]
+            except (ValueError, IndexError):
+                self.color = color_keys[0]
+
+            self.app.settings.set_string('last-color', self.color)
 
         context = self.get_style_context()
         context.add_class(self.color)
@@ -553,12 +563,12 @@ class SettingsWindow(XApp.PreferencesWindow):
         try:
             colors = [(x, y) for x, y in COLORS.items()]
             colors.append(('sep', ''))
-            colors.append(('random', _('Random')))
+            colors.append(('cycle', _('Cycle Colors')))
 
             page.pack_start(GSettingsComboBox(_("Default color"), SCHEMA, 'default-color', options=colors, valtype=str, separator='sep'), False, False, 0)
         except Exception as e:
             colors = [(x, y) for x, y in COLORS.items()]
-            colors.append(('random', _('Random')))
+            colors.append(('cycle', _('Cycle Colors')))
 
             page.pack_start(GSettingsComboBox(_("Default color"), SCHEMA, 'default-color', options=colors, valtype=str), False, False, 0)
 
@@ -643,6 +653,11 @@ class Application(Gtk.Application):
 
         if self.settings.get_boolean('first-run'):
             self.first_run()
+
+        # Backwards compatibility
+        # - Update random color option to cycle
+        if self.settings.get_string('default-color') == 'random':
+            self.settings.set_string('default-color', 'cycle')
 
         self.file_handler.connect('lists-changed', self.on_lists_changed)
         self.group_update_id = self.file_handler.connect('group-changed', self.on_group_changed)
@@ -1016,4 +1031,3 @@ if __name__ == "__main__":
     sticky = Application()
     sticky.autostart_mode = autostart_mode
     sticky.run()
-

--- a/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.sticky.gschema.xml
@@ -32,7 +32,7 @@
         <choice value='teal'/>
         <choice value='orange'/>
         <choice value='magenta'/>
-        <choice value='random'/>
+        <choice value='cycle'/>
       </choices>
       <aliases>
         <alias value='Red' target='red'/>
@@ -168,6 +168,14 @@
       <summary>Disable delete confirmation</summary>
       <description>
         When set to true, the user is not asked to confirm before deleting a note.
+      </description>
+    </key>
+
+    <key name='last-color' type='s'>
+      <default>""</default>
+      <summary>Last used color</summary>
+      <description>
+        This is an internal setting that is used to track the last used color when cycling colors is active.
       </description>
     </key>
 


### PR DESCRIPTION
Reimplementation of https://github.com/linuxmint/sticky/pull/61 to replace the random color option rather than create an additional setting.