### PR TITLE
Fixed RAM consumption when dragging notes

### DIFF
--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -238,8 +238,6 @@ class Note(Gtk.Window):
         self.height = new_height
         self.width = new_width
 
-        self.queue_update()
-
     def on_show(self, *args):
         self.showing = True
 


### PR DESCRIPTION
When a note is moved, removed the call to queue update the note since it was unnecessary and generated a bunch of new Note Entry instances that could end up costing a lot of memory