### PR TITLE
Position new notes relative to their parent

### DIFF
--- a/usr/lib/sticky/manager.py
+++ b/usr/lib/sticky/manager.py
@@ -258,7 +258,7 @@ class NotesManager(object):
         self.search_bar = self.builder.get_object('search_bar')
         GObject.Object.bind_property(search_toggle, 'active', self.search_bar, 'search_mode_enabled', GObject.BindingFlags.BIDIRECTIONAL)
 
-        self.builder.get_object('new_note').connect('clicked', self.new_note)
+        self.builder.get_object('new_note').connect('clicked', self.app.new_note)
         self.remove_note_button = self.builder.get_object('remove_note')
         self.remove_note_button.connect('clicked', self.remove_note)
         self.duplicate_note_button = self.builder.get_object('duplicate_note')
@@ -461,9 +461,6 @@ class NotesManager(object):
 
     def get_selected_note(self):
         return self.note_view.get_selected_children()[0].item.info
-
-    def new_note(self, *args):
-        self.app.new_note()
 
     def create_new_group(self, callback):
         entry = Gtk.Entry(visible=True)

--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -171,7 +171,7 @@ class Note(Gtk.Window):
 
         add_icon = Gtk.Image.new_from_icon_name('sticky-add', Gtk.IconSize.BUTTON)
         add_button = Gtk.Button(image=add_icon, relief=Gtk.ReliefStyle.NONE, name='window-button', valign=Gtk.Align.CENTER)
-        add_button.connect('clicked', self.app.new_note)
+        add_button.connect('clicked', self.app.new_note, self)
         add_button.connect('button-press-event', self.on_title_click)
         add_button.set_tooltip_text(_("New Note"))
         self.title_bar.pack_end(add_button, False, False, 0)
@@ -866,9 +866,13 @@ class Application(Gtk.Application):
         self.notes_hidden = True
         self.update_dummy_window()
 
-    def new_note(self, *args):
-        x = 40
-        y = 40
+    def new_note(self, button, parent=None):
+        if parent is None:
+            x = 40
+            y = 40
+        else:
+            x = parent.x + 20
+            y = parent.y + 20
         while(True):
             found = False
             for note_info in self.file_handler.get_note_list(self.note_group):


### PR DESCRIPTION
Notes created by pressing the + button on a note will now be positioned relative to that parent note.