### PR TITLE
Fix new notes opening over another

### DIFF
--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -361,11 +361,10 @@ class Note(Gtk.Window):
             self.cached_text = self.buffer.get_internal_markup()
             self.invalid_cache = False
 
-        (x, y) = self.get_position()
         (width, height) = self.get_size()
         info = {
-            'x': x,
-            'y': y,
+            'x': self.x,
+            'y': self.y,
             'height': height,
             'width': width,
             'color': self.color,


### PR DESCRIPTION
When creating new notes from the manager window they sometimes open over each other. This seems to be caused by get_position (in Note.get_info) returning the wrong values.

Since a notes position is updated when the it is moved, just going by those values rather than calling get_position seems to fix the problem.