### PR TITLE
Fix new_note parameter

### DIFF
--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -874,7 +874,7 @@ class Application(Gtk.Application):
         self.notes_hidden = True
         self.update_dummy_window()
 
-    def new_note(self, button, parent=None):
+    def new_note(self, button=None, parent=None):
         if parent is None:
             x = 40
             y = 40


### PR DESCRIPTION
When we click on the sticky icon on the panel, the following error message appears.

```
Traceback (most recent call last):
  File "/usr/lib/sticky/sticky.py", line 785, in on_tray_button_pressed
    self.activate_notes(time)
  File "/usr/lib/sticky/sticky.py", line 865, in activate_notes
    self.new_note()
TypeError: new_note() missing 1 required positional argument: 'button'
```