### PR TITLE
Not opening dummy_window and large borders on i3wm

### DIFF
--- a/usr/lib/sticky/sticky.py
+++ b/usr/lib/sticky/sticky.py
@@ -952,7 +952,7 @@ class Application(Gtk.Application):
         else:
             self.dummy_window.set_skip_taskbar_hint(True)
 
-        self.dummy_window.move(-2, -2)
+        self.dummy_window.close()
 
         if self.settings.get_boolean('desktop-window-state'):
             self.dummy_window.stick()

--- a/usr/share/sticky/sticky.css
+++ b/usr/share/sticky/sticky.css
@@ -74,11 +74,13 @@
 }
 
 #sticky-note decoration {
-    box-shadow: 0 3px 9px 1px transparent, 0 2px 6px 2px rgba(0, 0, 0, 0.5);
+    border: none;
+    margin: 0;
 }
 
 #sticky-note decoration:backdrop {
-    box-shadow: 0 3px 9px 1px transparent, 0 2px 6px 2px rgba(0, 0, 0, 0.2);
+    border: none;
+    margin: 0;
 }
 
 


### PR DESCRIPTION
When running sticky on i3wm I got dummy_window open (1) and notes with those large borders (2).

![image](https://github.com/user-attachments/assets/0638a59d-10cc-4f64-81cb-eef25a7ecb7f)

The PR fixes and I get this:

![image](https://github.com/user-attachments/assets/0dad4183-473b-42c1-8f2e-37d437bf3d0a)


Thanks for the great app!
